### PR TITLE
Proxy esm requests instead of redirect for CORS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ _site/
 node_modules/
 package-lock.json
 .DS_Store
+
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,6 @@
+[dev]
+targetPort = 8081
+
 [build]
   publish = "_site"
   command = "eleventy"
@@ -59,9 +62,11 @@
 [[redirects]]
   from = "/esm/cloud"
   to = "https://esm.sh/@fireproof/cloud@latest"
-  status = 301
+  force = true
+  status = 200
 
 [[redirects]]
   from = "/esm/core"
   to = "https://esm.sh/@fireproof/core@latest"
-  status = 301
+  force = true
+  status = 200


### PR DESCRIPTION
netlify doesn't add the proper headers with the current redirect rules so imports are failing due to CORS.