### PR TITLE
Mobile fixes for llms txt

### DIFF
--- a/tlas/index.html
+++ b/tlas/index.html
@@ -591,7 +591,7 @@
         position: absolute;
         z-index: 2;
         align-self: center;
-        border-color: var(--color-primary);
+        color: var(--color-primary);
         border-color: rgb(255, 220, 36);
         background: rgb(251, 211, 28);
         top: 75px;
@@ -599,12 +599,8 @@
       }
 
       .app-body .click-to-copy:hover {
-        /* color: linear-gradient(-45deg, #000000, #ff6f00, #ffa000, #000, #ff8200); */
-        /* background-size: 400% 400%; */
         background-color: #ff8200 ;
-        /* animation: gradient 120s ease infinite; */
         border-color: #ff8200;
-        /* color: #ff6f00; */
         text-shadow: 0px 1px 3px rgba(255, 255, 255, 1);
         box-shadow: 0px 2px 3px rgba(0, 0, 0, 1);
       }

--- a/tlas/index.html
+++ b/tlas/index.html
@@ -572,7 +572,8 @@
       #llm-txt {
         position: relative;
         z-index: 1;
-        width: 28rem;
+        width: 100%;
+        max-width: 28rem;
         height: 12rem;
         align-self: center;
         background: #ffc;


### PR DESCRIPTION
Before this change the LLMs.txt textarea was too wide on mobile (bleeding off the edges of the page) and the button was blue.

After this change the textarea is the right size and the button is out --color-primary black.

<img width="559" alt="Screenshot 2025-02-27 at 11 18 06 AM" src="https://github.com/user-attachments/assets/a37da04b-fdf6-4e5a-9962-9ab50d81f782" />
