### PR TITLE
No white text on yellow button

### DIFF
--- a/tlas/index.html
+++ b/tlas/index.html
@@ -592,7 +592,7 @@
         position: absolute;
         z-index: 2;
         align-self: center;
-        color: var(--color-primary);
+        color: rgba(44, 44, 44, 1);
         border-color: rgb(255, 220, 36);
         background: rgb(251, 211, 28);
         top: 75px;


### PR DESCRIPTION
Before this change the text on the yellow "click to copy" button was white in dark mode.

After this change it's always the near-black color.