### PR TITLE
Add log in link to header, remove github/discord header icons on mobile

### DIFF
--- a/tlas/index.html
+++ b/tlas/index.html
@@ -1287,7 +1287,7 @@
       <nav>
         <a class="text-buttons" href="https://use-fireproof.com/docs/welcome/" rel="noopener noreferrer">Docs</a>
         <a class="text-buttons" href="/blog/" rel="history">Blog</a>
-        <a class="text-buttons" href="https://dashboard.fireproof.storage">Log in</a>
+        <a class="text-buttons" href="https://connect.fireproof.storage">Sign in</a>
         <div class="header-link-icons">
           <a
             class="header-discord"


### PR DESCRIPTION
Before this change there was not link in the header to log in to [dashboard.fireproof.storage](https://dashboard.fireproof.storage).

After, there is. I'm removing the Github and Discord links on mobile to make room, on the basis that these links are still in the footer and, for Github, also in the hero.

<img width="300" alt="Screenshot 2025-03-05 at 12 43 40 PM" src="https://github.com/user-attachments/assets/bc713a5c-2aff-4b37-83ff-03f0d1f726ea" />

<img width="700" alt="Screenshot 2025-03-05 at 12 43 55 PM" src="https://github.com/user-attachments/assets/0a1f677a-f3d1-4fe8-bd53-6a2e05e993fd" />
